### PR TITLE
Avoid loading the default config if it's already configured.

### DIFF
--- a/Lib/CloudFiles.php
+++ b/Lib/CloudFiles.php
@@ -60,7 +60,9 @@ class CloudFiles extends Object {
 	*/
 	public static function getConfig($key = null){
 		if(empty(self::$configs)){
-			Configure::load('cloud_files');
+			if (!Configure::check('CloudFiles')) {
+				Configure::load('cloud_files');
+			}
 			self::$configs = Configure::read('CloudFiles');
 		}
 		if(empty($key)){


### PR DESCRIPTION
Some people don't or can't load a `Config/cloud_files.php` configuration file. So there have to be a way to avoid loading (inside the plugin).

For example, if I have a configuration file in another place that is not app/Config and I load that config, the plugin should not try to load it again (and possibly merge it).
